### PR TITLE
Updated to include handling for AVC (#193)

### DIFF
--- a/Community/Tdarr_Plugin_z18s_rename_files_based_on_codec.js
+++ b/Community/Tdarr_Plugin_z18s_rename_files_based_on_codec.js
@@ -26,6 +26,15 @@ module.exports.plugin = function plugin(file, librarySettings, inputs) {
       file._id = file._id.replace("264", "265");
       file.file = file.file.replace("264", "265");
     }
+    
+    //added handling for files with AVC in the name instead of h264/x264
+    if (
+      file.ffProbeData.streams[0].codec_name == "hevc" &&
+      file._id.includes("AVC")
+    ) {
+      file._id = file._id.replace("AVC", "HEVC");
+      file.file = file.file.replace("AVC", "HEVC");
+    }
 
     if (
       file.ffProbeData.streams[0].codec_name == "h264" &&


### PR DESCRIPTION
Added handling for AVC. Lots of my remuxes from Radarr had AVC in the filename as opposed to h264/x264. This replaces the AVC string with HEVC.